### PR TITLE
patch/add sample config files

### DIFF
--- a/examples/sample_config.conf
+++ b/examples/sample_config.conf
@@ -1,0 +1,107 @@
+# This is a HOCON configuration file. Enhanced to display the capabilities of HOCON.
+
+# Basic configurations for the 'api' subsystem.
+myconfig.api {
+    # Comment about error settings.
+    errors {
+        # Self-explanatory key-value pairs.
+        display-stack-trace = off
+        anotherSetting = {
+            value = 10
+            description = "A nested setting."
+        }
+    }
+
+    session {
+        scan-raw-header = false
+    }
+
+    checks {
+        input-json = off
+        output-json = off
+    }
+
+    # Using substitution. The read-window's value will be taken from another location in this file.
+    data.read-window = ${defaults.window}
+
+    # An array of strings.
+    permitted-sources = [
+        "https://xy.domain.com",
+        # ... truncated for brevity ...
+    ]
+
+    # Nested configurations.
+    system {
+        trusted-networks = [
+            # ... truncated for brevity ...
+        ]
+    }
+
+    space {
+        remote {
+            connection {
+                log-sent-data = off
+                log-incoming-data = off
+            }
+        }
+
+        logmode = "INFO"
+        stdout-logmode = "INFO"
+        actor {
+            trace {
+                receive = off
+                autoreceive = off
+                lifecycle = off
+                missed = off
+                stream-events = off
+            }
+        }
+    }
+}
+
+# Demonstrating variable substitution.
+defaults {
+    window = 140
+}
+
+# Demonstrating object merging.
+myconfig.pulse {
+    reconnect-automatically = false
+    # Merge the below with the previous configuration.
+    reconnect-automatically = true
+}
+
+space {
+    web {
+        server {
+            # Multi-line strings.
+            welcome-text = """
+                Welcome to our server.
+                We hope you enjoy your stay!
+                """
+            analysis {
+                warning-for-illegal-headers = off
+                content-limit = 10 MiB
+            }
+
+            # Using durations.
+            timeout-for-requests = 10 minutes
+            idle-limit = 15 minutes
+            queue-limit = 10
+        }
+
+        client {
+            idle-limit = 15 minutes
+        }
+    }
+
+    actor {
+        trace {
+            receive = off
+            autoreceive = off
+            lifecycle = off
+            missed = off
+            stream-events = off
+        }
+    }
+}

--- a/examples/sample_config.toml
+++ b/examples/sample_config.toml
@@ -1,0 +1,62 @@
+# This is a TOML document with added features.
+
+# Table declaration.
+[console]
+# Booleans
+isActive = true
+# Strings
+entryCmd = { default = "/bin/terminal", windows = "cmdprompt.exe" }
+# Integers
+historyScroll = 5000
+# Date and Time
+lastUpdated = 2023-10-19T20:20:30Z
+
+[proxy]
+isActive = true
+bindPort = 25
+
+# Array of Tables
+[[proxy.allowedPorts]]
+id = 1
+range = "5101-5105"
+
+[[proxy.allowedPorts]]
+id = 2
+values = [ 13000, 5101 ]
+
+# Inline Table
+defaultGroups = { name = "Network Remote Users", type = "OS-specific", purpose = "access for networking" }
+
+# Duration
+inactiveLimit = { default = "10m", max = "1h", min = "1s" }
+fileTransferActive = true
+fileTransferPort = 2025
+connectionDir = ""
+
+# Key/Value pairs within a table.
+[proxy.services]
+remoteDisplay = 5101
+remoteApp = "13000"
+
+[proxy.certification]
+nation = "XY"
+entity = "generic"
+
+# Array of strings.
+[account]
+modifyMainPassword = false
+leadAsManager = false
+autoFolders = ["Main", "Files", "Load"]
+autoHiddenFolders = []
+passwordSize = 16
+
+# Nested Tables
+[account.settings]
+    # Floats
+    maxLoad = 32.5
+    # Arrays
+    userRoles = ["admin", "editor", "viewer"]
+
+[account.settings.preferences]
+    theme = "dark"
+    language = "en-US"


### PR DESCRIPTION
## Description
Added sample configuration files in TOML and HOCON. This can be used to draw smaller examples for test cases and to look at different scenarios when writing parsers.