### PR TITLE
feature/map-fileContent-to-lineNumber

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/ConfigMate/configmate/analyzer"
 	"github.com/ConfigMate/configmate/parsers"
@@ -100,6 +101,25 @@ func main() {
 
 					// Get rules
 					rules := ruleBook.Rules
+
+					// Map the file content to the corresponding line numbers
+					filesLines := make(map[string]map[int]string)
+					for path := range files {
+						// Read file
+						fileData, err := os.ReadFile(path)
+						if err != nil {
+							return err
+						}
+
+						// Create line map
+						lineMap, err := utils.CreateLineMap(fileData)
+						if err != nil {
+							return nil
+						}
+
+						// Append line map to filesLines
+						filesLines[path] = lineMap
+					}
 
 					// Get analyzer
 					analyzer := &analyzer.AnalyzerImpl{}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"sort"
 
 	"github.com/ConfigMate/configmate/analyzer"
 	"github.com/ConfigMate/configmate/parsers"

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/ConfigMate/configmate/analyzer"
 	"github.com/ConfigMate/configmate/parsers"
@@ -103,9 +104,9 @@ func main() {
 
 					// Map the file content to the corresponding line numbers
 					filesLines := make(map[string]map[int]string)
-					for path := range files {
+					for alias, details := range ruleBook.Files {
 						// Read file
-						fileData, err := os.ReadFile(path)
+						fileData, err := os.ReadFile(details.Path)
 						if err != nil {
 							return err
 						}
@@ -117,7 +118,24 @@ func main() {
 						}
 
 						// Append line map to filesLines
-						filesLines[path] = lineMap
+						filesLines[alias] = lineMap
+					}
+
+					// Print filesLines to check if it's correct
+					for path, lineMap := range filesLines {
+						fmt.Printf("For file: %s\n", path)
+
+						// Create a slice for the line numbers and sort it
+						keys := make([]int, 0, len(lineMap))
+						for k := range lineMap {
+							keys = append(keys, k)
+						}
+						sort.Ints(keys)
+
+						// Print lines in sorted order
+						for _, k := range keys {
+							fmt.Printf("Line %d: %s\n", k, lineMap[k])
+						}
 					}
 
 					// Get analyzer

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"sort"
 
 	"github.com/ConfigMate/configmate/analyzer"
 	"github.com/ConfigMate/configmate/parsers"
@@ -82,7 +81,7 @@ func main() {
 
 					// Parse rulebooks
 					files := make(map[string]*parsers.Node)
-					for _, file := range ruleBook.Files {
+					for alias, file := range ruleBook.Files {
 						// Read the file
 						data, err := os.ReadFile(file.Path)
 						if err != nil {
@@ -96,7 +95,7 @@ func main() {
 						}
 
 						// Append the parse result to the files map
-						files[file.Path] = parser
+						files[alias] = parser
 					}
 
 					// Get rules
@@ -119,23 +118,6 @@ func main() {
 
 						// Append line map to filesLines
 						filesLines[alias] = lineMap
-					}
-
-					// Print filesLines to check if it's correct
-					for path, lineMap := range filesLines {
-						fmt.Printf("For file: %s\n", path)
-
-						// Create a slice for the line numbers and sort it
-						keys := make([]int, 0, len(lineMap))
-						for k := range lineMap {
-							keys = append(keys, k)
-						}
-						sort.Ints(keys)
-
-						// Print lines in sorted order
-						for _, k := range keys {
-							fmt.Printf("Line %d: %s\n", k, lineMap[k])
-						}
 					}
 
 					// Get analyzer

--- a/utils/create_line_map.go
+++ b/utils/create_line_map.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+func CreateLineMap(fileContent []byte) (map[int]string, error) {
+	// Check if fileContent is nil or empty
+	if len(fileContent) == 0 {
+		return nil, fmt.Errorf("fileContent is empty or nil")
+	}
+
+	// Create a map of line numbers to lines (content)
+	lineMap := make(map[int]string)
+	for i, line := range strings.Split(string(fileContent), "\n") {
+		lineMap[i+1] = line
+	}
+
+	return lineMap, nil
+}

--- a/utils/create_line_map_test.go
+++ b/utils/create_line_map_test.go
@@ -1,0 +1,172 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestTomlFile_CreateLineMap tests the CreateLineMap function of the TomlFile struct.
+func TestTomlFile_CreateLineMap(t *testing.T) {
+	// Input
+	var tomlFile = []byte(`# This is a TOML configuration for the Rulebook
+name = "Sample Rulebook"
+description = "This is a sample rulebook for experimentation."
+
+# Files to be checked
+[files.file1]
+path = "/examples/configurations/sample_config.json"
+format = "json"`)
+
+	// Test cases
+	type testCase struct {
+		input    []byte
+		expected map[int]string
+		err      bool
+	}
+
+	// Mock result
+	expectedMap := map[int]string{
+		1: "# This is a TOML configuration for the Rulebook",
+		2: "name = \"Sample Rulebook\"",
+		3: "description = \"This is a sample rulebook for experimentation.\"",
+		4: "",
+		5: "# Files to be checked",
+		6: "[files.file1]",
+		7: "path = \"/examples/configurations/sample_config.json\"",
+		8: "format = \"json\"",
+	}
+
+	testCases := []testCase{
+		{
+			input:    tomlFile,
+			expected: expectedMap,
+			err:      false,
+		},
+	}
+
+	// Run tests
+	for _, test := range testCases {
+		actual, err := CreateLineMap(test.input)
+
+		if err != nil && !test.err {
+			t.Errorf("Unexpected error: %s", err)
+		} else if err == nil && test.err {
+			t.Errorf("Expected error, got nil")
+		} else if !reflect.DeepEqual(actual, test.expected) {
+			t.Errorf("Expected %v, got %v", test.expected, actual)
+		}
+	}
+}
+
+// TestJsonFile_CreateLineMap tests the CreateLineMap function of the JsonFile struct.
+func TestJsonFile_CreateLineMap(t *testing.T) {
+	// Input
+	var jsonFile = []byte(`{
+	"name": "Sample Rulebook",
+	"description": "This is a sample rulebook for experimentation.",
+	"files": {
+		"file1": {
+			"path": "/examples/configurations/sample_config.json",
+			"format": "json"
+		}
+	}
+}`)
+
+	// Test cases
+	type testCase struct {
+		input    []byte
+		expected map[int]string
+		err      bool
+	}
+
+	// Mock result
+	expectedMap := map[int]string{
+		1:  "{",
+		2:  "\t\"name\": \"Sample Rulebook\",",
+		3:  "\t\"description\": \"This is a sample rulebook for experimentation.\",",
+		4:  "\t\"files\": {",
+		5:  "\t\t\"file1\": {",
+		6:  "\t\t\t\"path\": \"/examples/configurations/sample_config.json\",",
+		7:  "\t\t\t\"format\": \"json\"",
+		8:  "\t\t}",
+		9:  "\t}",
+		10: "}",
+	}
+
+	testCases := []testCase{
+		{
+			input:    jsonFile,
+			expected: expectedMap,
+			err:      false,
+		},
+	}
+
+	// Run tests
+	for _, test := range testCases {
+		actual, err := CreateLineMap(test.input)
+
+		if err != nil && !test.err {
+			t.Errorf("Unexpected error: %s", err)
+		} else if err == nil && test.err {
+			t.Errorf("Expected error, got nil")
+		} else if !reflect.DeepEqual(actual, test.expected) {
+			t.Errorf("Expected %v, got %v", test.expected, actual)
+		}
+	}
+}
+
+func TestHoconFile_CreateLineMap(t *testing.T) {
+	// Input
+	var hoconFile = []byte(`name = "Sample Rulebook"
+description = "This is a sample rulebook for experimentation."
+
+# Files to be checked
+files {
+	file1 {
+		path = "/examples/configurations/sample_config.json"
+		format = "json"
+	}
+}`)
+
+	// Test cases
+	type testCase struct {
+		input    []byte
+		expected map[int]string
+		err      bool
+	}
+
+	// Mock result
+	expectedMap := map[int]string{
+		1:  "name = \"Sample Rulebook\"",
+		2:  "description = \"This is a sample rulebook for experimentation.\"",
+		3:  "",
+		4:  "# Files to be checked",
+		5:  "files {",
+		6:  "\tfile1 {",
+		7:  "\t\tpath = \"/examples/configurations/sample_config.json\"",
+		8:  "\t\tformat = \"json\"",
+		9:  "\t}",
+		10: "}",
+	}
+
+	testCases := []testCase{
+		{
+			input:    hoconFile,
+			expected: expectedMap,
+			err:      false,
+		},
+	}
+
+	// Run tests
+	for _, test := range testCases {
+		actual, err := CreateLineMap(test.input)
+
+		if err != nil && !test.err {
+			t.Errorf("Unexpected error: %s", err)
+		} else if err == nil && test.err {
+			t.Errorf("Expected error, got nil")
+		} else if !reflect.DeepEqual(actual, test.expected) {
+			t.Errorf("Expected %v, got %v", test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
## Description
- Created a function to map the content of the file to the corresponding line number
- Map every file that is inside the rulebook

### Issue Addressing
#76 

### Example :
*Config File Example*
```json
{
	"name": "Sample Rulebook",
	"description": "This is a sample rulebook for experimentation.",
	"files": {
		"file1": {
			"path": "/examples/configurations/sample_config.json",
			"format": "json"
		}
	}
}
```

*Map Output:*
```
1:  "{",
2:  "\t\"name\": \"Sample Rulebook\",",
3:  "\t\"description\": \"This is a sample rulebook for experimentation.\",",
4:  "\t\"files\": {",
5:  "\t\t\"file1\": {",
6:  "\t\t\t\"path\": \"/examples/configurations/sample_config.json\",",
7:  "\t\t\t\"format\": \"json\"",
8:  "\t\t}",
9:  "\t}",
10: "}",
```